### PR TITLE
Bump version to 1.5.2, Add support for RedHat

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 go:
  download_url: "https://storage.googleapis.com/golang"
- src_file_name: "go1.4.2.linux-amd64.tar.gz"
- src_file_sha256: 141b8345932641483c2437bdbd65488a269282ac85f91170805c273f03dd223b
+ src_file_name: "go1.5.2.linux-amd64.tar.gz"
+ src_file_sha256: b8041ec8a7c0da29dab0b110206794d016165d6d0806976d39b7a99d899aa015

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,11 +21,11 @@ galaxy_info:
   # platform on this list, let us know and we'll get it added!
   #
   platforms:
-  #- name: EL
-  #  versions:
+  - name: EL
+    versions:
   #  - all
   #  - 5
-  #  - 6
+    - 6
   #  - 7
   #- name: GenericUNIX
   #  versions:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,23 +1,23 @@
 ---
-- name: Debin | Create go directory before src download
+- name: Debian | Create go directory before src download
   file: >
    path=/usr/local/src/go/
    state=directory
    owner=root group=root mode=0755
 
-- name: Debin | Download Go src file
+- name: Debian | Download Go src file
   get_url: >
    url={{ go.download_url }}/{{go.src_file_name}}
    dest=/usr/local/src/go/{{go.src_file_name}}
    sha256sum={{go.src_file_sha256}}
 
-- name: Debin | Extract the src Go file
+- name: Debian | Extract the src Go file
   unarchive: >
    src=/usr/local/src/go/{{go.src_file_name}}
    dest=/usr/local
    copy=no
 
-- name: Debin | Symlink Go into /usr/local/bin
+- name: Debian | Symlink Go into /usr/local/bin
   file: >
    src=/usr/local/go/bin/{{ item }}
    dest=/usr/local/bin/{{ item }}

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,1 +1,33 @@
 ---
+- name: RedHat | Create go directory before src download
+  file: >
+   path=/usr/local/src/go/
+   state=directory
+   owner=root group=root mode=0755
+
+- name: RedHat | Download Go src file
+  get_url: >
+   url={{ go.download_url }}/{{go.src_file_name}}
+   dest=/usr/local/src/go/{{go.src_file_name}}
+   sha256sum={{go.src_file_sha256}}
+
+- name: RedHat | Extract the src Go file
+  unarchive: >
+   src=/usr/local/src/go/{{go.src_file_name}}
+   dest=/usr/local
+   copy=no
+
+- name: RedHat | Symlink Go into /usr/local/bin
+  file: >
+   src=/usr/local/go/bin/{{ item }}
+   dest=/usr/local/bin/{{ item }}
+   state=link
+  with_items:
+    - go
+    - godoc
+    - gofmt
+
+- name: RedHat | Add go to the PATH system wide
+  lineinfile: >
+   dest=/etc/profile
+   line="export PATH=$PATH:/usr/local/go/bin"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Check for supported operating system on target
   fail:
     msg: "The operating system of the target machine ({{ inventory_hostname }}) is not currently supported."
-  when: ansible_os_family not in ['Debian']
+  when: ansible_os_family not in ['Debian', 'RedHat']
 
 - name: include os specific variables
   include_vars: "{{ ansible_os_family }}.yml"
@@ -11,11 +11,11 @@
   include: Debian.yml
   when: ansible_os_family == 'Debian'
 
+- name: Include RedHat specific tasks
+  include: RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
 # ToDo
-#
-#- name: Include RedHat specific tasks
-#  include: RedHat.yml
-#  when: ansible_os_family == 'RedHat'
 #
 #- name: Include Suse specific tasks
 #  include: Suse.yml


### PR DESCRIPTION
Thanks for making this available! Here are a few little enhancements.

* Bump Go version to 1.5.2
* Add support for RedHat (note that the tasks are identical to Debian)
* Also fixed the "Debin" typos